### PR TITLE
Replace component-specific font overrides with GlobalFontConsumer attribute

### DIFF
--- a/src/LiveSplit.Text/UI/Components/TextComponent.cs
+++ b/src/LiveSplit.Text/UI/Components/TextComponent.cs
@@ -9,6 +9,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TextFont)]
 public class TextComponent : IComponent
 {
     protected TextTextComponent InternalComponent { get; set; }
@@ -111,6 +112,16 @@ public class TextComponent : IComponent
     public void SetSettings(System.Xml.XmlNode settings)
     {
         Settings.SetSettings(settings);
+    }
+
+    public void MigrateFontOverrides(Options.FontOverrides overrides)
+    {
+        if (Settings.OverrideFont1 && Settings.Font1 != null)
+        {
+            overrides.OverrideTextFont = true;
+            overrides.TextFont = (Font)Settings.Font1.Clone();
+            Settings.OverrideFont1 = false;
+        }
     }
 
     public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)

--- a/src/LiveSplit.Text/UI/Components/TextComponentSettings.Designer.cs
+++ b/src/LiveSplit.Text/UI/Components/TextComponentSettings.Designer.cs
@@ -32,12 +32,6 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel6 = new System.Windows.Forms.TableLayoutPanel();
-            this.lblFont = new System.Windows.Forms.Label();
-            this.btnFont = new System.Windows.Forms.Button();
-            this.chkFont = new System.Windows.Forms.CheckBox();
-            this.label5 = new System.Windows.Forms.Label();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
             this.btnTextColor = new System.Windows.Forms.Button();
@@ -47,12 +41,6 @@
             this.txtOne = new System.Windows.Forms.TextBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel7 = new System.Windows.Forms.TableLayoutPanel();
-            this.lblFont2 = new System.Windows.Forms.Label();
-            this.btnFont2 = new System.Windows.Forms.Button();
-            this.chkFont2 = new System.Windows.Forms.CheckBox();
-            this.label7 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
@@ -70,14 +58,10 @@
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            this.groupBox5.SuspendLayout();
-            this.tableLayoutPanel6.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
-            this.groupBox6.SuspendLayout();
-            this.tableLayoutPanel7.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
             this.SuspendLayout();
@@ -104,8 +88,8 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 221F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 9F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(445, 529);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
@@ -127,95 +111,17 @@
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 153F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 95F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Controls.Add(this.groupBox5, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.groupBox4, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.txtOne, 1, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 3;
+            this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.Size = new System.Drawing.Size(433, 196);
             this.tableLayoutPanel2.TabIndex = 0;
-            // 
-            // groupBox5
-            // 
-            this.tableLayoutPanel2.SetColumnSpan(this.groupBox5, 4);
-            this.groupBox5.Controls.Add(this.tableLayoutPanel6);
-            this.groupBox5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox5.Location = new System.Drawing.Point(3, 115);
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(427, 78);
-            this.groupBox5.TabIndex = 2;
-            this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "Font";
-            // 
-            // tableLayoutPanel6
-            // 
-            this.tableLayoutPanel6.ColumnCount = 3;
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 145F));
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
-            this.tableLayoutPanel6.Controls.Add(this.lblFont, 1, 1);
-            this.tableLayoutPanel6.Controls.Add(this.btnFont, 2, 1);
-            this.tableLayoutPanel6.Controls.Add(this.chkFont, 0, 0);
-            this.tableLayoutPanel6.Controls.Add(this.label5, 0, 1);
-            this.tableLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel6.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel6.Name = "tableLayoutPanel6";
-            this.tableLayoutPanel6.RowCount = 2;
-            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel6.Size = new System.Drawing.Size(421, 59);
-            this.tableLayoutPanel6.TabIndex = 0;
-            // 
-            // lblFont
-            // 
-            this.lblFont.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblFont.AutoSize = true;
-            this.lblFont.Location = new System.Drawing.Point(148, 37);
-            this.lblFont.Name = "lblFont";
-            this.lblFont.Size = new System.Drawing.Size(189, 13);
-            this.lblFont.TabIndex = 4;
-            this.lblFont.Text = "Font";
-            // 
-            // btnFont
-            // 
-            this.btnFont.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnFont.Location = new System.Drawing.Point(343, 32);
-            this.btnFont.Name = "btnFont";
-            this.btnFont.Size = new System.Drawing.Size(75, 23);
-            this.btnFont.TabIndex = 1;
-            this.btnFont.Text = "Choose...";
-            this.btnFont.UseVisualStyleBackColor = true;
-            this.btnFont.Click += new System.EventHandler(this.btnFont1_Click);
-            // 
-            // chkFont
-            // 
-            this.chkFont.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkFont.AutoSize = true;
-            this.tableLayoutPanel6.SetColumnSpan(this.chkFont, 2);
-            this.chkFont.Location = new System.Drawing.Point(7, 6);
-            this.chkFont.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkFont.Name = "chkFont";
-            this.chkFont.Size = new System.Drawing.Size(330, 17);
-            this.chkFont.TabIndex = 0;
-            this.chkFont.Text = "Override Layout Settings";
-            this.chkFont.UseVisualStyleBackColor = true;
-            this.chkFont.CheckedChanged += new System.EventHandler(this.chkFont_CheckedChanged);
-            // 
-            // label5
-            // 
-            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 37);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(139, 13);
-            this.label5.TabIndex = 5;
-            this.label5.Text = "Font:";
             // 
             // groupBox4
             // 
@@ -317,95 +223,17 @@
             this.tableLayoutPanel3.ColumnCount = 2;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 34.22222F));
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 65.77778F));
-            this.tableLayoutPanel3.Controls.Add(this.groupBox6, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this.label4, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.groupBox3, 0, 1);
             this.tableLayoutPanel3.Controls.Add(this.txtTwo, 1, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 3;
+            this.tableLayoutPanel3.RowCount = 2;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 9F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(433, 196);
             this.tableLayoutPanel3.TabIndex = 0;
-            // 
-            // groupBox6
-            // 
-            this.tableLayoutPanel3.SetColumnSpan(this.groupBox6, 4);
-            this.groupBox6.Controls.Add(this.tableLayoutPanel7);
-            this.groupBox6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox6.Location = new System.Drawing.Point(3, 115);
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(427, 78);
-            this.groupBox6.TabIndex = 2;
-            this.groupBox6.TabStop = false;
-            this.groupBox6.Text = "Font";
-            // 
-            // tableLayoutPanel7
-            // 
-            this.tableLayoutPanel7.ColumnCount = 3;
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 145F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
-            this.tableLayoutPanel7.Controls.Add(this.lblFont2, 1, 1);
-            this.tableLayoutPanel7.Controls.Add(this.btnFont2, 2, 1);
-            this.tableLayoutPanel7.Controls.Add(this.chkFont2, 0, 0);
-            this.tableLayoutPanel7.Controls.Add(this.label7, 0, 1);
-            this.tableLayoutPanel7.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel7.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel7.Name = "tableLayoutPanel7";
-            this.tableLayoutPanel7.RowCount = 2;
-            this.tableLayoutPanel7.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel7.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel7.Size = new System.Drawing.Size(421, 59);
-            this.tableLayoutPanel7.TabIndex = 0;
-            // 
-            // lblFont2
-            // 
-            this.lblFont2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblFont2.AutoSize = true;
-            this.lblFont2.Location = new System.Drawing.Point(148, 37);
-            this.lblFont2.Name = "lblFont2";
-            this.lblFont2.Size = new System.Drawing.Size(189, 13);
-            this.lblFont2.TabIndex = 4;
-            this.lblFont2.Text = "Font";
-            // 
-            // btnFont2
-            // 
-            this.btnFont2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnFont2.Location = new System.Drawing.Point(343, 32);
-            this.btnFont2.Name = "btnFont2";
-            this.btnFont2.Size = new System.Drawing.Size(75, 23);
-            this.btnFont2.TabIndex = 1;
-            this.btnFont2.Text = "Choose...";
-            this.btnFont2.UseVisualStyleBackColor = true;
-            this.btnFont2.Click += new System.EventHandler(this.btnFont2_Click);
-            // 
-            // chkFont2
-            // 
-            this.chkFont2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkFont2.AutoSize = true;
-            this.tableLayoutPanel7.SetColumnSpan(this.chkFont2, 2);
-            this.chkFont2.Location = new System.Drawing.Point(7, 6);
-            this.chkFont2.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkFont2.Name = "chkFont2";
-            this.chkFont2.Size = new System.Drawing.Size(330, 17);
-            this.chkFont2.TabIndex = 0;
-            this.chkFont2.Text = "Override Layout Settings";
-            this.chkFont2.UseVisualStyleBackColor = true;
-            this.chkFont2.CheckedChanged += new System.EventHandler(this.chkFont2_CheckedChanged);
-            // 
-            // label7
-            // 
-            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 37);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(139, 13);
-            this.label7.TabIndex = 5;
-            this.label7.Text = "Font:";
             // 
             // label4
             // 
@@ -586,18 +414,12 @@
             this.groupBox1.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            this.groupBox5.ResumeLayout(false);
-            this.tableLayoutPanel6.ResumeLayout(false);
-            this.tableLayoutPanel6.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.tableLayoutPanel5.ResumeLayout(false);
             this.tableLayoutPanel5.PerformLayout();
             this.groupBox2.ResumeLayout(false);
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
-            this.groupBox6.ResumeLayout(false);
-            this.tableLayoutPanel7.ResumeLayout(false);
-            this.tableLayoutPanel7.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
@@ -630,18 +452,6 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.TextBox txtOne;
         private System.Windows.Forms.TextBox txtTwo;
-        private System.Windows.Forms.GroupBox groupBox5;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel6;
-        private System.Windows.Forms.Label lblFont;
-        private System.Windows.Forms.Button btnFont;
-        private System.Windows.Forms.CheckBox chkFont;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.GroupBox groupBox6;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel7;
-        private System.Windows.Forms.Label lblFont2;
-        private System.Windows.Forms.Button btnFont2;
-        private System.Windows.Forms.CheckBox chkFont2;
-        private System.Windows.Forms.Label label7;
         private System.Windows.Forms.CheckBox chkTwoRows;
         private System.Windows.Forms.CheckBox chkCustomVariable;
         private System.Windows.Forms.ToolTip toolTipCustomVariable;

--- a/src/LiveSplit.Text/UI/Components/TextComponentSettings.cs
+++ b/src/LiveSplit.Text/UI/Components/TextComponentSettings.cs
@@ -26,12 +26,11 @@ public partial class TextComponentSettings : UserControl
     public string Text1 { get; set; }
     public string Text2 { get; set; }
 
-    public Font Font1 { get; set; }
-    public string Font1String => string.Format("{0} {1}", Font1.FontFamily.Name, Font1.Style);
+    // Legacy font overrides — read from old configs, not written or exposed in UI
     public bool OverrideFont1 { get; set; }
-    public Font Font2 { get; set; }
-    public string Font2String => string.Format("{0} {1}", Font2.FontFamily.Name, Font2.Style);
+    public Font Font1 { get; set; }
     public bool OverrideFont2 { get; set; }
+    public Font Font2 { get; set; }
 
     public LayoutMode Mode { get; set; }
     public bool Display2Rows { get; set; }
@@ -52,10 +51,6 @@ public partial class TextComponentSettings : UserControl
         BackgroundGradient = GradientType.Plain;
         Text1 = "Text";
         Text2 = "";
-        OverrideFont1 = false;
-        OverrideFont2 = false;
-        Font1 = new Font("Segoe UI", 16, FontStyle.Regular, GraphicsUnit.Pixel);
-        Font2 = new Font("Segoe UI", 16, FontStyle.Regular, GraphicsUnit.Pixel);
 
         chkCustomVariable.DataBindings.Add("Checked", this, "CustomVariable", false, DataSourceUpdateMode.OnPropertyChanged);
 
@@ -63,8 +58,6 @@ public partial class TextComponentSettings : UserControl
         btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
         chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
         btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-        lblFont.DataBindings.Add("Text", this, "Font1String", false, DataSourceUpdateMode.OnPropertyChanged);
-        lblFont2.DataBindings.Add("Text", this, "Font2String", false, DataSourceUpdateMode.OnPropertyChanged);
 
         cmbGradientType.SelectedIndexChanged += cmbGradientType_SelectedIndexChanged;
         cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -72,18 +65,6 @@ public partial class TextComponentSettings : UserControl
         btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
         txtOne.DataBindings.Add("Text", this, "Text1");
         txtTwo.DataBindings.Add("Text", this, "Text2");
-        chkFont.DataBindings.Add("Checked", this, "OverrideFont1", false, DataSourceUpdateMode.OnPropertyChanged);
-        chkFont2.DataBindings.Add("Checked", this, "OverrideFont2", false, DataSourceUpdateMode.OnPropertyChanged);
-    }
-
-    private void chkFont2_CheckedChanged(object sender, EventArgs e)
-    {
-        label7.Enabled = lblFont2.Enabled = btnFont2.Enabled = chkFont2.Checked;
-    }
-
-    private void chkFont_CheckedChanged(object sender, EventArgs e)
-    {
-        label5.Enabled = lblFont.Enabled = btnFont.Enabled = chkFont.Checked;
     }
 
     private void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
@@ -101,8 +82,6 @@ public partial class TextComponentSettings : UserControl
         chkCustomVariable_CheckedChanged(null, null);
         chkOverrideTextColor_CheckedChanged(null, null);
         chkOverrideTimeColor_CheckedChanged(null, null);
-        chkFont_CheckedChanged(null, null);
-        chkFont2_CheckedChanged(null, null);
         if (Mode == LayoutMode.Horizontal)
         {
             chkTwoRows.Enabled = false;
@@ -165,7 +144,7 @@ public partial class TextComponentSettings : UserControl
 
     private int CreateSettingsNode(XmlDocument document, XmlElement parent)
     {
-        return SettingsHelper.CreateSetting(document, parent, "Version", "1.4") ^
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.5") ^
         SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
         SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
         SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
@@ -175,10 +154,6 @@ public partial class TextComponentSettings : UserControl
         SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
         SettingsHelper.CreateSetting(document, parent, "Text1", Text1) ^
         SettingsHelper.CreateSetting(document, parent, "Text2", Text2) ^
-        SettingsHelper.CreateSetting(document, parent, "Font1", Font1) ^
-        SettingsHelper.CreateSetting(document, parent, "Font2", Font2) ^
-        SettingsHelper.CreateSetting(document, parent, "OverrideFont1", OverrideFont1) ^
-        SettingsHelper.CreateSetting(document, parent, "OverrideFont2", OverrideFont2) ^
         SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
         SettingsHelper.CreateSetting(document, parent, "CustomVariable", CustomVariable);
     }
@@ -186,21 +161,5 @@ public partial class TextComponentSettings : UserControl
     private void ColorButtonClick(object sender, EventArgs e)
     {
         SettingsHelper.ColorButtonClick((Button)sender, this);
-    }
-
-    private void btnFont1_Click(object sender, EventArgs e)
-    {
-        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(Font1, 11, 26);
-        dialog.FontChanged += (s, ev) => Font1 = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-        dialog.ShowDialog(this);
-        lblFont.Text = Font1String;
-    }
-
-    private void btnFont2_Click(object sender, EventArgs e)
-    {
-        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(Font2, 11, 26);
-        dialog.FontChanged += (s, ev) => Font2 = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-        dialog.ShowDialog(this);
-        lblFont2.Text = Font2String;
     }
 }


### PR DESCRIPTION
## Summary
- Replace component-specific font overrides with `[GlobalFontConsumer]` attribute
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688