### PR TITLE
Fix Color override panel layout

### DIFF
--- a/src/LiveSplit.Text/UI/Components/TextComponentSettings.Designer.cs
+++ b/src/LiveSplit.Text/UI/Components/TextComponentSettings.Designer.cs
@@ -88,9 +88,9 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(445, 529);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 141F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 141F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(445, 369);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // groupBox1
@@ -100,7 +100,7 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(3, 90);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(439, 215);
+            this.groupBox1.Size = new System.Drawing.Size(439, 135);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Left Text";
@@ -119,8 +119,8 @@
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(433, 196);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(433, 116);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // groupBox4
@@ -130,16 +130,17 @@
             this.groupBox4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox4.Location = new System.Drawing.Point(3, 32);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(427, 77);
+            this.groupBox4.Size = new System.Drawing.Size(427, 80);
             this.groupBox4.TabIndex = 1;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Color";
             // 
             // tableLayoutPanel5
             // 
-            this.tableLayoutPanel5.ColumnCount = 2;
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel5.ColumnCount = 3;
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 147F));
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 94F));
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel5.Controls.Add(this.btnTextColor, 1, 1);
             this.tableLayoutPanel5.Controls.Add(this.chkOverrideTextColor, 0, 0);
             this.tableLayoutPanel5.Controls.Add(this.label1, 0, 1);
@@ -149,7 +150,7 @@
             this.tableLayoutPanel5.RowCount = 2;
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel5.Size = new System.Drawing.Size(421, 58);
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(421, 61);
             this.tableLayoutPanel5.TabIndex = 0;
             // 
             // btnTextColor
@@ -157,7 +158,7 @@
             this.btnTextColor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.btnTextColor.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnTextColor.Location = new System.Drawing.Point(213, 32);
+            this.btnTextColor.Location = new System.Drawing.Point(150, 32);
             this.btnTextColor.Name = "btnTextColor";
             this.btnTextColor.Size = new System.Drawing.Size(23, 23);
             this.btnTextColor.TabIndex = 1;
@@ -168,10 +169,11 @@
             // 
             this.chkOverrideTextColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkOverrideTextColor.AutoSize = true;
+            this.tableLayoutPanel5.SetColumnSpan(this.chkOverrideTextColor, 3);
             this.chkOverrideTextColor.Location = new System.Drawing.Point(7, 6);
             this.chkOverrideTextColor.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkOverrideTextColor.Name = "chkOverrideTextColor";
-            this.chkOverrideTextColor.Size = new System.Drawing.Size(200, 17);
+            this.chkOverrideTextColor.Size = new System.Drawing.Size(411, 17);
             this.chkOverrideTextColor.TabIndex = 0;
             this.chkOverrideTextColor.Text = "Override Layout Settings";
             this.chkOverrideTextColor.UseVisualStyleBackColor = true;
@@ -183,7 +185,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(3, 37);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(204, 13);
+            this.label1.Size = new System.Drawing.Size(141, 13);
             this.label1.TabIndex = 5;
             this.label1.Text = "Color:";
             // 
@@ -211,9 +213,9 @@
             this.tableLayoutPanel1.SetColumnSpan(this.groupBox2, 4);
             this.groupBox2.Controls.Add(this.tableLayoutPanel3);
             this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Location = new System.Drawing.Point(3, 311);
+            this.groupBox2.Location = new System.Drawing.Point(3, 231);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(439, 215);
+            this.groupBox2.Size = new System.Drawing.Size(439, 135);
             this.groupBox2.TabIndex = 5;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Right Text";
@@ -231,8 +233,8 @@
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 2;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(433, 196);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(433, 116);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // label4
@@ -252,7 +254,7 @@
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox3.Location = new System.Drawing.Point(3, 32);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(427, 77);
+            this.groupBox3.Size = new System.Drawing.Size(427, 80);
             this.groupBox3.TabIndex = 1;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Color";
@@ -272,7 +274,7 @@
             this.tableLayoutPanel4.RowCount = 2;
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(421, 58);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(421, 61);
             this.tableLayoutPanel4.TabIndex = 1;
             // 
             // btnTimeColor
@@ -407,7 +409,7 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "TextComponentSettings";
             this.Padding = new System.Windows.Forms.Padding(7);
-            this.Size = new System.Drawing.Size(459, 543);
+            this.Size = new System.Drawing.Size(459, 383);
             this.Load += new System.EventHandler(this.TextComponentSettings_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();


### PR DESCRIPTION
## Problem

The font override commit (ad8e076) changed `tableLayoutPanel2`/`tableLayoutPanel3` row 1 from `Absolute 83F` to `Percent 100F`. Because the inner Color `groupBox` is `Dock=Fill` in that cell, a `Percent 100F` row consumes all remaining space in the parent panel, stretching the Color groupBox from its intended ~77F to ~167F — more than 2× taller.

Additionally, the Left Color button and Right Color button were never horizontally aligned: Left's `tableLayoutPanel5` used 2 columns × `Percent 50F`, putting the button at x=213, while Right's `tableLayoutPanel4` used `Absolute 147F + Absolute 94F + Percent 100F`, putting it at x=150 — a 63F gap that was pre-existing but became more visible after the font row removal.

## Changes

- Restore `Absolute` row sizing:
  - Outer `tableLayoutPanel1` rows 3, 4: `Percent 50F` → `Absolute 141F`
  - Inner `tableLayoutPanel2`/`3` row 1 (Color): `Percent 100F` → `Absolute 86F` (with ~3F internal slack to prevent bottom clipping caused by GroupBox title overhead + WinForms rounding)
- Shrink form size from `(459, 543)` → `(459, 383)` to match the actual content height after Font row removal
- Update downstream `Location`/`Size` design hints accordingly
- Align Left Color button with Right by changing `tableLayoutPanel5` from `2 columns × 50%` to `3 columns: 147F + 94F + 100%` (mirroring `tableLayoutPanel4`), so both Color buttons now land at x=150. Updated `chkOverrideTextColor` `ColumnSpan` to 3 to keep the checkbox spanning the full panel.

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- Color override `groupBox` returns to its intended ~80F height with no bottom clipping
- Left and Right Color buttons are now horizontally aligned at x=150
